### PR TITLE
Version bump -> 1.33beta2

### DIFF
--- a/buf.c
+++ b/buf.c
@@ -62,23 +62,31 @@ get_user_entry(char *buf, struct USER_ENTRY * ue)
  * ret: next position in buffer or NULL
  */
 
+/* This function was re-written by PL 2025-07-25 to prevent segfault and for increased portability */
 char *
-get_file_entry(char *buf, struct FILE_ENTRY * fe)
+get_file_entry(char *buf, struct FILE_ENTRY *fe)
 {
-    char *tmpbuf, *ptr;
+    char *sep, *newline;
 
-    tmpbuf = strchr(buf, ':');
-    if (!tmpbuf)
+    sep = strchr(buf, ':');
+    if (!sep)
         return NULL;
-    *tmpbuf = 0;
-    strcpy(fe->name, buf);
-    *tmpbuf = ':';
-    ptr = strchr(tmpbuf, '\n');
-    *ptr = 0;
-    strcpy(fe->desc, (tmpbuf + 1));
-    *ptr = '\n';
-    buf = ptr;
-    while (*buf && (*buf == '\n'))
+    *sep = '\0'; // Temporarily null-terminate filename
+    strncpy(fe->name, buf, sizeof(fe->name));
+    fe->name[sizeof(fe->name)-1] = '\0'; // Ensure null-termination
+    *sep = ':'; // Restore original char
+
+    newline = strchr(sep, '\n');
+    if (!newline)
+        return NULL;
+
+    *newline = '\0'; // Temporarily null-terminate desc
+    strncpy(fe->desc, sep + 1, sizeof(fe->desc));
+    fe->desc[sizeof(fe->desc)-1] = '\0'; // Ensure null-termination
+    *newline = '\n'; // Restore newline
+
+    buf = newline;
+    while (*buf && *buf == '\n')
         buf++;
     return buf;
 }

--- a/command_list.c
+++ b/command_list.c
@@ -49,6 +49,7 @@ const struct COMMAND_ENTRY command_list[] = {
     { "cmd_mail", cmd_mail, },
     { "cmd_mod_login", cmd_mod_login, },
     { "cmd_mod_note", cmd_mod_note, },
+    { "cmd_mod_numlines", cmd_mod_numlines, },
     { "cmd_mod_pinfo", cmd_mod_pinfo, },
     { "cmd_mod_sig", cmd_mod_sig, },
     { "cmd_mod_timeout", cmd_mod_timeout, },

--- a/etc/help.eng/mod_numlines
+++ b/etc/help.eng/mod_numlines
@@ -1,0 +1,20 @@
+Arguments:
+<number-of-lines>
+
+Description:
+The command allows you to set a screen length that matches your
+terminal. Normally not needed as the screen length should
+be automatically detected, but in rare cases this does
+not work, and then it is automatically set to 24.
+
+If you have already changed your screen length, but want to return to
+automatic detection, enter either '0' or 'A'-
+
+If you only give the command "Change screen length" you will be guided,
+if you already know what length you want, you can enter it as an
+argument instead.
+
+Example:
+'Change screen length' - helps you choose the right length.
+'Change screen length 24' - sets the screen length to 24.
+'Change screen length 0' - turns on automatic detection.

--- a/etc/help.eng/nethack
+++ b/etc/help.eng/nethack
@@ -1,0 +1,3 @@
+Description:
+  Nethack is a popular 'rogue-like' game that was originally
+  released in 1987.

--- a/etc/help.swe/mod_numlines
+++ b/etc/help.swe/mod_numlines
@@ -1,0 +1,20 @@
+Argument:
+  <antal-rader>
+
+Beskrivning:
+  Kommandot låter dig ställa in en skärmlängd som matchar med din
+  terminal. Ska i normala fall inte behövas då skärmlängden ska
+  detekteras automatiskt, men i sällsynta fall fungerar inte
+  detta, och då sätts den per automatik till 24.
+
+  Om du redan har ändrat din skärmlängd, men vill återgå till
+  automatisk detektering anger du antingen '0' eller 'A'-
+
+  Ger du enbart kommandot "Ändra skärmlängd" får du vägledning,
+  om du redan vet vilken längd du vill ha kan du ange den som
+  argument istället.
+
+Exempel:
+  'Ändra skärmlängd' - hjälper dig att välja rätt längd.
+  'Ändra skärmlängd 24' - sätter skärmlängden på 24.
+  'Ändra skärmlängd 0' - slår på automatisk detektering.

--- a/etc/help.swe/nethack
+++ b/etc/help.swe/nethack
@@ -1,0 +1,3 @@
+Beskrivning:
+  Nethack är ett populärt 'rogueliknande' spel som urpsrungligen 
+  släpptes 1987.

--- a/etc/parse.eng
+++ b/etc/parse.eng
@@ -17,6 +17,8 @@ Change conferencename:cmd_change_cname:Change conference name
 Change replyconference:cmd_change_comc:Change reply conference
 Change personal (information):cmd_mod_pinfo:Change personal information
 Change plan:cmd_mod_sig:Change your plan file
+Change rows:cmd_mod_numlines:Set number of rows
+Change screen (length):cmd_mod_numlines:Change number of screen rows
 Change timeout:cmd_mod_timeout:Change timeout period
 Create conference:cmd_create_conf:Create a new conference
 Delete article:cmd_delete_text:Delete a specific article

--- a/etc/parse.swe
+++ b/etc/parse.swe
@@ -6,6 +6,7 @@
 Addera r{ttigheter:cmd_add_rights:Addera r{ttigheter f|r en anv{ndare i aktuellt m|te 
 (Definera) alias:cmd_alias:Definierar ett alias f|r ett kommando
 (L{sa) alla (texter):cmd_readall:Visar alla dina ol{sta texter
+Antal rader:cmd_mod_numlines: [ndra din sk{rml{ngd
 Beskriv (fil):cmd_describe:Beskriv en fil i m|tets filarea
 Avprioritera (m|te):cmd_deprio:Avprioritera m|te
 (Skriv) brev:cmd_mail:Skicka brev till anv{ndare
@@ -96,6 +97,7 @@ Visa ol{sta (texter):cmd_reclaim_unread:Ol{smarkerar dina ol{sta texter direkt.
 [ndra kommentarsm|te:cmd_change_comc:[ndra kommentarsm|te till ett m|te
 [ndra personuppgifter:cmd_mod_pinfo:[ndra dina personuppgifter
 [ndra plan:cmd_mod_sig:[ndra din plan-fil
+[ndra sk{rml{ngd:cmd_mod_numlines:[ndra din sk{rml{ngd
 [ndra timeout:cmd_mod_timeout:[ndra tid f|r inaktivitetsutloggning
 [ndra uppstartskommandon:cmd_mod_login:[ndra vilka kommandon som k|rs vid login
 Nethack:cmd_nethack:Spela nethack

--- a/etc/sklaffrc
+++ b/etc/sklaffrc
@@ -15,6 +15,8 @@ beep = 1
 header = 0
 strip = 0
 presbeep = 0
+ansi = 0
+utf8 = +
 ![timeout]
 0
 ![paid]

--- a/file.c
+++ b/file.c
@@ -57,13 +57,15 @@ rebuild_index_file(void)
     if ((fd3 = open_file(fn3, OPEN_CREATE)) == -1) {
         return -1;
     }
-    getcwd(cwd, LINE_LEN);
-
+    if (getcwd(cwd, LINE_LEN) == NULL) {
+    perror("getcwd"); /* Modified on 2025-07-25 by PL */
+    return -1;
+    }
     sprintf(filed, "%s/%d", FILE_DB, Current_conf);
-    
-/*  fprintf(stderr, "FILE_DB: %s, Current_conf: %d\n", FILE_DB, Current_conf); */ /* Debugging */
-
-    chdir(filed);
+    if (chdir(filed) == -1) {
+    perror("chdir to filed"); /* Modified on 2025-07-25 by PL */
+    return -1;
+    }
     sprintf(fn2, "/tmp/%d", getpid());
     if (fork()) {
         (void) wait(&subba);
@@ -77,8 +79,10 @@ rebuild_index_file(void)
         execl(LSPRGM, LSPRGM, LSOPT, (char *) 0);
     }
 
-    chdir(cwd);
-
+    if (chdir(cwd) == -1) {
+    perror("chdir back to cwd"); /* Modified on 2025-07-25 by PL */
+    return -1;
+    }
     if ((oldbuf = read_file(fd)) == NULL) {
         return -1;
     }
@@ -104,14 +108,20 @@ rebuild_index_file(void)
                 if (buf) {
                     if (!strcmp(currfile, fe.name)) {
                         sprintf(outrec, "%s:%s\n", currfile, fe.desc);
-                        write(fd3, outrec, strlen(outrec));
+		    if (write(fd3, outrec, strlen(outrec)) == -1) {
+                        perror("write"); /* Modified on 2025-07-25 by PL */
+                        return -1;
+                        }
                         break;
                     }
                 }
             }
             if (!buf) {
                 sprintf(outrec, "%s:%s\n", currfile, "");
-                write(fd3, outrec, strlen(outrec));
+                        if (write(fd3, outrec, strlen(outrec)) == -1) {
+                            perror("write"); /* Modified on 2025-07-25 by PL */
+                            return -1;
+                            }
             }
         } else {
             *buf2 = '\0';

--- a/lib/output.c
+++ b/lib/output.c
@@ -56,60 +56,67 @@ output(char *fmt,...)
     char *p1, *p2;
     char fmt2[HUGE_LINE_LEN], outline[HUGE_LINE_LEN];
     char tmpline[LONG_LINE_LEN];
-
+    int in_ansi = Ansi_output ? 0 : -1;  /* modified on 2025-07-30, PL: disable ANSI logic unless allowed */
     va_start(args, fmt);
-    vsprintf(fmt2, fmt, args);
+    vsnprintf(fmt2, sizeof(fmt2), fmt, args); /* modified on 2025-07-25, PL: replaced vsprintf with vsnprintf for safety */
     va_end(args);
     tmp = fmt2;
     tmp2 = outline;
     while (*tmp) {
         if (Beep || Special || (*tmp != 7)) {
             *tmp2 = *tmp;
+
+            /* modified on 2025-07-30, PL: skip character translation inside ANSI escape sequences */
+            if (in_ansi != -1 && *tmp == '\033' && *(tmp + 1) == '[') {
+                in_ansi = 1;
+            } else if (in_ansi && ((*tmp >= 'A' && *tmp <= 'Z') || (*tmp >= 'a' && *tmp <= 'z'))) {
+                in_ansi = 0;
+            }
+
             tmp++;
             if (*tmp2 == '\n') {
                 *tmp2 = '\r';
                 tmp2++;
                 *tmp2 = '\n';
             }
-            if (Ibm) {
-                if (*tmp2 == '}')
-                    *tmp2 = (char) 134;
-                else if (*tmp2 == '{')
-                    *tmp2 = (char) 132;
-                else if (*tmp2 == '|')
-                    *tmp2 = (char) 148;
-                else if (*tmp2 == ']')
-                    *tmp2 = (char) 143;
-                else if (*tmp2 == '[')
-                    *tmp2 = (char) 142;
-                else if (*tmp2 == 0x5c)
-                    *tmp2 = (char) 153;
-            } else if (Iso8859) {
-                if (*tmp2 == '}')
-                    *tmp2 = (char) 229;
-                else if (*tmp2 == '{')
-                    *tmp2 = (char) 228;
-                else if (*tmp2 == '|')
-                    *tmp2 = (char) 246;
-                else if (*tmp2 == ']')
-                    *tmp2 = (char) 197;
-                else if (*tmp2 == '[')
-                    *tmp2 = (char) 196;
-                else if (*tmp2 == 0x5c)
-                    *tmp2 = (char) 214;
-            } else if (Mac) {
-                if (*tmp2 == '}')
-                    *tmp2 = (char) 140;
-                else if (*tmp2 == '{')
-                    *tmp2 = (char) 138;
-                else if (*tmp2 == '|')
-                    *tmp2 = (char) 154;
-                else if (*tmp2 == ']')
-                    *tmp2 = (char) 129;
-                else if (*tmp2 == '[')
-                    *tmp2 = (char) 128;
-                else if (*tmp2 == 0x5c)
-                    *tmp2 = (char) 133;
+
+            if (!in_ansi) {
+                if (Utf8) {
+                    if (*tmp2 == '}') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0xA5; }
+                    else if (*tmp2 == '{') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0xA4; }
+                    else if (*tmp2 == '|') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0xB6; }
+                    else if (*tmp2 == ']') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0x85; }
+                    else if (*tmp2 == '[') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0x84; }
+                    else if (*tmp2 == 0x5c) { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0x96; }
+                } else if (Ibm) {
+                    if (*tmp2 == '}') *tmp2 = (char) 134;
+                    else if (*tmp2 == '{') *tmp2 = (char) 132;
+                    else if (*tmp2 == '|') *tmp2 = (char) 148;
+                    else if (*tmp2 == ']') *tmp2 = (char) 143;
+                    else if (*tmp2 == '[') *tmp2 = (char) 142;
+                    else if (*tmp2 == 0x5c) *tmp2 = (char) 153;
+                } else if (Iso8859) {
+                    if (*tmp2 == '}') *tmp2 = (char) 229;
+                    else if (*tmp2 == '{') *tmp2 = (char) 228;
+                    else if (*tmp2 == '|') *tmp2 = (char) 246;
+                    else if (*tmp2 == ']') *tmp2 = (char) 197;
+                    else if (*tmp2 == '[') *tmp2 = (char) 196;
+                    else if (*tmp2 == 0x5c) *tmp2 = (char) 214;
+                } else if (Utf8) {
+                    if (*tmp2 == '}') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0xA5; }
+                    else if (*tmp2 == '{') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0xA4; }
+                    else if (*tmp2 == '|') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0xB6; }
+                    else if (*tmp2 == ']') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0x85; }
+                    else if (*tmp2 == '[') { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0x84; }
+                    else if (*tmp2 == 0x5c) { *tmp2 = (char)0xC3; tmp2++; *tmp2 = (char)0x96; }
+                } else if (Mac) {
+                    if (*tmp2 == '}') *tmp2 = (char) 140;
+                    else if (*tmp2 == '{') *tmp2 = (char) 138;
+                    else if (*tmp2 == '|') *tmp2 = (char) 154;
+                    else if (*tmp2 == ']') *tmp2 = (char) 129;
+                    else if (*tmp2 == '[') *tmp2 = (char) 128;
+                    else if (*tmp2 == 0x5c) *tmp2 = (char) 133;
+                }
             }
             tmp2++;
         } else {
@@ -180,7 +187,6 @@ output(char *fmt,...)
     return 0;
 }
 
-
 /* Output for external applications */
 
 int
@@ -196,3 +202,21 @@ outputex(char *fmt,...)
     /* No use to add Iso8859 support. Eight bit is stripped anyway when sent
      * over network. */
 }
+/*
+* Needed for ansi outputs with lot's of args
+* PL 2025-07-31
+*/
+int
+output_ansi_fmt(const char *ansi_fmt, const char *plain_fmt, ...)
+{
+    va_list args;
+    char buf[HUGE_LINE_LEN];
+    const char *fmt = Ansi_output ? ansi_fmt : plain_fmt;
+
+    va_start(args, plain_fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    return output("%s", buf);   /* returns -1 on error */
+}
+

--- a/lib/prog_name.c
+++ b/lib/prog_name.c
@@ -49,7 +49,10 @@ prog_name(char *pname)
         strcpy(absname, pw->pw_shell);
         return absname;
     }
-    getcwd(cwd, HUGE_LINE_LEN);
+    if (getcwd(cwd, HUGE_LINE_LEN) == NULL) {
+    perror("getcwd"); /* keeps linux compiler happy 2025-07-25, PL */
+    return NULL;
+    }
 
     if (*pname == '/') {
         strcpy(absname, pname);

--- a/lib/unlock.c
+++ b/lib/unlock.c
@@ -61,7 +61,7 @@ unlock(int fd)
         printf("\nError %d at flock() on file: %s. Please note this error and inform us.\n",
                errno, filename);
     } else {
-	/* Optional debug logging. Can be commented out if it produces too much output, but I'll leave it here for now */
-        debuglog("Unlocked: %s\n", 20);
+      /* Optional debug logging that turned out to be broken, needs fix sometime (prob next time file unlocking becomes an issue.. :) PL 2025*/
+      /* debuglog("Unlocked: %s\n", 20); */
     }
 }

--- a/msg.c
+++ b/msg.c
@@ -48,7 +48,7 @@ add_to_mlist(struct MSG_ENTRY * me)
 void
 list_mlist(int max, int type_filter)
 {
-    int count, i, r = 0, l;
+    int count, i, r = 0; /* we must declare "l" later to silence warning when compiling for ENGLISH language 2025-08-11 PL */
     struct MSG_LIST *current;
     struct MSG_ENTRY **me;
     LINE name;
@@ -88,9 +88,9 @@ list_mlist(int max, int type_filter)
         case MSG_I:
             r = output("%s %s\n", name, me[i]->msg);
             break;
-        case MSG_MY:
-            l = strlen(name);
+        case MSG_MY: {            
 #ifdef SWEDISH
+            size_t l = strlen(name);              /* declared now only for Swedish */
             if (name[l - 1] == 's')
                 r = output("%s %s\n", name, me[i]->msg);
             else
@@ -99,6 +99,7 @@ list_mlist(int max, int type_filter)
             r = output("%s's %s\n", name, me[i]->msg);
 #endif
             break;
+        }
         case MSG_SMS:
             r = output("%s\n", me[i]->msg);
             break;
@@ -137,7 +138,7 @@ newmsg(int tmp)
 int
 display_msg(int num)
 {
-    int nl, l, r, fd, x;
+    int nl, r, fd, x; /* Again, we declare l later 2025-08-11 PL */
     char *oldbuf, *buf;
     sigset_t sigmask, oldsigmask;
     LINE name, msgfile;
@@ -229,8 +230,9 @@ display_msg(int num)
             if (Special)
                 output("#");
             user_name(me.num, name);
-            l = strlen(name);
+            {
 #ifdef SWEDISH
+            size_t l = strlen(name);
             if (name[l - 1] == 's')
                 r = output("%s %s\n", name, me.msg);
             else
@@ -238,6 +240,7 @@ display_msg(int num)
 #else
             r = output("%s's %s\n", name, me.msg);
 #endif
+            }
             if (r == -1) {
                 break;
             }

--- a/newstoss.c
+++ b/newstoss.c
@@ -122,7 +122,6 @@ main(int argc, char *argv[])
     //printf("I think we're all set now.\n");
     //printf("Press ENTER to continue\n");
     //getchar();
-
     strcpy(ng, argv[1]);
     ptr = NULL;
     char *line = strtok(buf, "\n");
@@ -136,7 +135,7 @@ main(int argc, char *argv[])
     }
 
     if (!ptr) {
-    fprintf(stderr, "[ERROR] Group '%s' not found in active file!\n", argv[1]);
+    fprintf(stderr, "[ERROR] Group '%s' not found in active-file!\n", argv[1]);
     exit(1);
     }
 
@@ -273,7 +272,7 @@ main(int argc, char *argv[])
         rf = rf->next;
         free(top);
     }
- if (first) notify_all_processes(SIGNAL_NEW_TEXT);
+    if (first) notify_all_processes(SIGNAL_NEW_TEXT);
     printf("Now done");
     printf("\n");
     exit(0);

--- a/survreport.c
+++ b/survreport.c
@@ -198,7 +198,9 @@ post_survey_result(char *resultbuf, struct TEXT_HEADER * th, int conf, int ouid,
     if (close_file(fdoutfile) == -1) {
         return -1L;
     }
-    chown(textfile, ouid, ogrp);
+    if (chown(textfile, ouid, ogrp) == -1) {			/* 2025-08-10 PL compiler silencer */
+    /* maybe perror("chown"); or debuglog(...) */
+    }
 
     if (write_file(fd, nbuf) == -1) {
         return -1L;


### PR DESCRIPTION
# Please help me test and report any issues :)

So many changes here, sorry only in Swedish for now :

Kända buggar :
* Sporadiska skräptecken vid login / logout bland annat (undersöks just nu)
* UTF8 ballar ur i editorn ibland - oklart varför - påverkar ej funktionen - felsökning pågår

Nya funktioner :
* UTF-8 stöds (i prompt och när man skriver och läser texter - kan finnas andra ställen jag missat...), och aktiveras genom flagga (i nuläget avstängd "by default").
* Snyggare prompt (enligt mig) - kan numera ändras i sklaff.h (#define PROMPT).
* Skärmlängden ska nu detekteras automatiskt och inställningen behålls session ut. Funkar inte detta får man 24 rader, som det var innan. Det finns även ett nytt kommando nedan.
* Nytt kommando - Ändra skärmlängd (OBS! glöm ej att kopiera /etc/parse.eng och /etc/parse.swe, samt hjälpfilerna 
*"mod_numlines" för respektive språk (även nethack ligger bland hjälpfilerna nu).
* Färger stöds via ny flagga (ANSI), dock är ej färgläggningen färdig (tog mig friheten att låna delta citys färgschema sålänge hehe).

Buggfixar :
* Mailtoss förstår nu att spoolen ofta är tom och loggar inte längre det "felet"
* Makefile kopierar nu också newstoss och mailtoss till /usr/local/bin så man inte glömmer det
* Visar rätt antal texter i "lista möten" i brevlåda och möten
* "make distrib" helt omskriven för moderna förhållanden, mycket praktiskt vid testkörning utanför github
* Ett par småfixar i den engelska versionen
* Basen "krashar" inte längre om .plan-fil saknas
* Vi skapar nu usenet header i utgående post på ett mer robust sätt för att slippa fel i inews
* Fixade en egen bugg jag själv infört eftersom compilern klagade över unused variables om news-postning var avstängd.
* Replace_conf gav ibland segfault när man mailade användare utanför sklaffkom, nu fixat

Övrigt :
* Visar riktigt namn i usenet-header och "footer" (när den infon finns, dvs typ jämt)
* Strippar onödiga tecken i författarens namn på usenet-inlägg
* Avkodar "=?UTF-8?B?...?=...." strängar i namn och subject på usenet-inlägg
* Ändlöst antal småfixar gör nu att vi kan behålla "-werror" även vid kompilering på linux
* Ett antal fixar som förebygger segfault och istället visar rimliga felmeddelanden