### PR TITLE
Fixes issue 57 (extra characters in signal-messages)

### DIFF
--- a/msg.c
+++ b/msg.c
@@ -30,6 +30,15 @@
 #include "sklaff.h"
 #include "ext_globals.h"
 
+static void clear_prompt(int num) /* Little helper to avoid extra '(') 2025-08-26 PL */
+{
+    int x;
+    output("\r");
+    for (x = 0; x < num; x++)
+        output(" ");
+    output("\r");
+}
+
 void
 add_to_mlist(struct MSG_ENTRY * me)
 {
@@ -138,7 +147,7 @@ newmsg(int tmp)
 int
 display_msg(int num)
 {
-    int nl, r, fd, x; /* Again, we declare l later 2025-08-11 PL */
+    int nl, r, fd; /* Again, we declare l later 2025-08-11 PL */
     char *oldbuf, *buf;
     sigset_t sigmask, oldsigmask;
     LINE name, msgfile;
@@ -187,9 +196,7 @@ display_msg(int num)
 
         add_to_mlist(&me);
         if ((me.type == MSG_SAY) && Say) {
-            for (x = 0; x < num; x++) {
-                output("\b \b");
-            }
+            clear_prompt(num);    /* modified on 2025-08-25, PL */
             nl = 1;
             if (output("\007%s: %s\n",
                     user_name(me.num, name), me.msg) == -1) {
@@ -197,9 +204,7 @@ display_msg(int num)
             }
         } else if ((me.type == MSG_YELL) && Shout) {
             if (!nl)
-                for (x = 0; x < num; x++) {
-                    output("\b \b");
-                }
+                    clear_prompt(num);    /* modified on 2025-08-25, PL */
             nl = 1;
             if (output("\007%s %s %s\n", user_name(me.num, name), MSG_YELLS,
                     me.msg) == -1) {
@@ -207,9 +212,7 @@ display_msg(int num)
             }
         } else if ((me.type == MSG_I) && Shout) {
             if (!nl)
-                for (x = 0; x < num; x++) {
-                    output("\b \b");
-                }
+                    clear_prompt(num);    /* modified on 2025-08-25, PL */
             nl = 1;
             if (!Presbeep || Special)
                 output("\007");
@@ -221,9 +224,7 @@ display_msg(int num)
             }
         } else if ((me.type == MSG_MY) && Shout) {
             if (!nl)
-                for (x = 0; x < num; x++) {
-                    output("\b \b");
-                }
+                    clear_prompt(num);    /* modified on 2025-08-25, PL */
             nl = 1;
             if (!Presbeep || Special)
                 output("\007");
@@ -246,18 +247,14 @@ display_msg(int num)
             }
         } else if ((me.type == MSG_SMS) && Shout) {
             if (!nl)
-                for (x = 0; x < num; x++) {
-                    output("\b \b");
-                }
+                    clear_prompt(num);    /* modified on 2025-08-25, PL */
             nl = 1;
             if (output("%s\n", me.msg) == -1) {
                 break;
             }
         } else if ((me.type == MSG_LOGIN) && (Present || Special)) {
             if (!nl)
-                for (x = 0; x < num; x++) {
-                    output("\b \b");
-                }
+                clear_prompt(num);    /* modified on 2025-08-25, PL */
             nl = 1;
             if (Presbeep || Special)
                 output("\007");
@@ -266,9 +263,7 @@ display_msg(int num)
             }
         } else if ((me.type == MSG_LOGOUT) && (Present || Special)) {
             if (!nl)
-                for (x = 0; x < num; x++) {
-                    output("\b \b");
-                }
+                    clear_prompt(num);    /* modified on 2025-08-25, PL */
             nl = 1;
             if (Presbeep || Special)
                 output("\007");
@@ -283,9 +278,7 @@ display_msg(int num)
                 (me.type != MSG_LOGIN) &&
             (me.type != MSG_LOGOUT)) {
             if (!nl)
-                for (x = 0; x < num; x++) {
-                    output("\b \b");
-                }
+               clear_prompt(num);    /* modified on 2025-08-25, PL */
             nl = 1;
             if (output("\007%s %s: %s\n", MSG_STRANGEMSG,
                     user_name(me.num, name), me.msg) == -1) {


### PR DESCRIPTION
Small fix to get rid of extra "(" on the "real time notifications" SIGNAL calls