### PR TITLE
Two small but important fixes :

### DIFF
--- a/lang.h
+++ b/lang.h
@@ -1023,7 +1023,7 @@
 #define MSG_EDRECOVER	"Resuming an aborted editing session..."
 #define MSG_NOSAVE	"You can't save your text here, please move it."
 #define MSG_QUSE	"j = quote line, a = quote all lines, q = abort, any other key = next line"
-#define MSG_NOBODYQUOTE	"Sorry, there's "no body" to be found for quation\n"
+#define MSG_NOBODYQUOTE	"Sorry, there's 'no body' to be found for quation\n"
 
 #define MSG_SURVHELP1    "Question types for surveys\n\n"
 #define MSG_SURVHELP2    "Free text      : ## text\n"
@@ -1105,7 +1105,7 @@
 #define MSG_FLAG18N     2
 #define MSG_FLAG18F      "ANSI colors"
 #define MSG_FLAG19	"utf8"
-#define MSG_FLAG19N	"2"
+#define MSG_FLAG19N	1
 #define MSG_FLAG19F	"UTF-8 (character set)"
 #define MSG_NOFLAG	"You must supply a flagname."
 #define MSG_PCWARN	"You should turn off IBM-PC first."
@@ -1284,7 +1284,7 @@
 #define MSG_INSMODEM	"\nModem    : "
 #define MSG_INSTELE	"\nTelephone: "
 #define MSG_INSPOST     "\nE-mail : "
-#define MSG_APPLIED	"Your application har been posted.\nWelcome back.\n\n"
+#define MSG_APPLIED	"Your application has been posted.\nWelcome back.\n\n"
 #define MSG_UIDINUSE	"login-name in use by another user."
 
 /* mailtoss.c */

--- a/mailtoss.c
+++ b/mailtoss.c
@@ -76,7 +76,15 @@ main(int argc, char *argv[])
     oldbuf = buf;
     if (close_file(fd) == -1)
         exit(1);
-    unlink(mbox);
+    //unlink(mbox);
+	/* modified on 2025-09-14, PL: truncate the spool file instead of deleting it */
+	int trunc_fd = open(mbox, O_WRONLY | O_TRUNC);
+	if (trunc_fd >= 0) {
+    close(trunc_fd);
+	} else {
+    perror("open for truncating spool file");
+	}
+	/* If you want the old behaviour, delete the above code block and uncomment unlink(mbox); */
 
     if (strlen(buf) < 50)
         exit(0);


### PR DESCRIPTION
* Fixes in lang.h for the English version (turning on UTF-8 didn't work, improper usage of "" within a string, and a spelling error fixed)

* mailtoss.c : trunctate instead of delete the spool"file" (commonly /var/mail/username). This way permissions is no longer an issue, and it's more compatible with other parts of the system.